### PR TITLE
allow building on jdk 1.6

### DIFF
--- a/src/java/nginx/clojure/HackUtils.java
+++ b/src/java/nginx/clojure/HackUtils.java
@@ -138,7 +138,7 @@ public class HackUtils {
             
             return clone;
         } catch (Exception ex) {
-            throw new AssertionError("can not cloneThreadLocalMap", ex);
+            throw new AssertionError(ex);
         }
     }
     
@@ -151,7 +151,7 @@ public class HackUtils {
         	UNSAFE.putObject(clone, threadLocalMapEntryQueueFieldOffset, UNSAFE.getObject(entry, threadLocalMapEntryQueueFieldOffset));
         	return clone;
         } catch (Exception e) {
-            throw new AssertionError("can not cloneThreadLocalMapEntry", e);
+            throw new AssertionError(e);
         }
     }
 


### PR DESCRIPTION
The original constructor is present on JDK 7+ only.

