### PR TITLE
enable the building of javadocs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,7 @@
              "Can-Retransform-Classes" "true"
              }
   :javadoc-opts {
-             :package-names [["nginx-clojure"]]
+             :package-names ["nginx.clojure"]
              }
   :profiles {
              :provided {

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :dependencies [
                  ]
   :plugins [[lein-junit "1.1.7"]
+            [lein-javadoc "0.2.0"]
             ;[venantius/ultra "0.1.9"]
             ]
   ;; CLJ source code path
@@ -27,6 +28,9 @@
   :manifest {"Premain-Class" "nginx.clojure.wave.JavaAgent"
              "Can-Redefine-Classes" "true"
              "Can-Retransform-Classes" "true"
+             }
+  :javadoc-opts {
+             :package-names [["nginx-clojure"]]
              }
   :profiles {
              :provided {


### PR DESCRIPTION
The building of javadocs does not seem to work on JDK6 at all but works fine using JDK8.

