### PR TITLE
Fixing using correct number of argument, else binary data will fail

### DIFF
--- a/src/clojure/nginx/clojure/core.clj
+++ b/src/clojure/nginx/clojure/core.clj
@@ -195,7 +195,7 @@
     (.addListener ch ch (proxy [WholeMessageAdapter] [max-message-size]
                           (onOpen [c] (if on-open (on-open c)))
                           (onWholeTextMessage [c msg] (if on-message (on-message c msg)))
-                          (onWholeBiniaryMessage [c msg rem?] (if on-message (on-message c msg)))
+                          (onWholeBiniaryMessage [c msg] (if on-message (on-message c msg)))
                           (onClose ;([c] (if on-close (on-close c "0")))
                                    ([c status reason] (if on-close (on-close c (str status ":" reason)))))
                           (onError [c status] (if on-error (on-error c (NginxClojureAsynSocket/errorCodeToString status)))))))


### PR DESCRIPTION
I came across a problem when trying to send images as binary over a websocket. In the pet project websockets with strings worked great. It turned out it was easily fixable, and with this I no longer have the error. So now in my on-message I get a bytebuffer.