### PR TITLE
Update ngx_http_clojure_module.c

### DIFF
--- a/src/c/ngx_http_clojure_module.c
+++ b/src/c/ngx_http_clojure_module.c
@@ -1646,7 +1646,6 @@ static ngx_int_t ngx_http_clojure_check_access_jvm_cp(ngx_http_clojure_main_conf
 		ngx_uid_t ouid = geteuid();
 		ngx_gid_t ogid = getegid();
 		char *username = ccf->username;
-		struct passwd *pw;
 
 		/*TODO: remove this check when we merge -Djava.class.path with jvm_classpath.*/
 		if (!mcf->jvm_cp) {

--- a/src/c/ngx_http_clojure_module.c
+++ b/src/c/ngx_http_clojure_module.c
@@ -1670,23 +1670,20 @@ static ngx_int_t ngx_http_clojure_check_access_jvm_cp(ngx_http_clojure_main_conf
 				return NGX_ERROR;
 			}
 			ngx_log_debug2(NGX_LOG_DEBUG_CORE, log, 0, "geteuid now %ud:%ud", geteuid(), getegid());
-		}else if (ccf->user == (uid_t) NGX_CONF_UNSET_UINT) {
-			pw = getpwuid (ouid);
-			username = pw->pw_name;
 		}
-
+		
 		for (i = 0; i < mcf->jvm_cp->nelts; i++) {
-			ngx_log_debug2(NGX_LOG_DEBUG_CORE, log, 0, "checking %V, nginx user:%s", &elts[i], username);
+			ngx_log_debug2(NGX_LOG_DEBUG_CORE, log, 0, "checking %V, nginx user with id : %ud ", &elts[i], ouid);
 			if (ngx_http_clojure_faccessat((char *)elts[i].data, log) != 0) {
 				err = ngx_errno;
-				ngx_log_error(NGX_LOG_EMERG, log, err, "check access jvm classpath file \"%V\" failed by os user \"%s\"", &elts[i], username);
+				ngx_log_error(NGX_LOG_EMERG, log, err, "check access jvm classpath file \"%V\" failed by os user with id  \"%ud\"", &elts[i], ouid);
 				rc = NGX_ERROR;
 
 				if (err == EACCES) {
 					ngx_log_error(NGX_LOG_EMERG, log, 0,
-							"it is caused by os user \"%s\" has no direct access permission, "
+							"it is caused by os user with id \"%ud\" has no direct access permission, "
 									"or search permission (viz. x-permission for a directory) is denied "
-									"for one of the directories in the path prefix of pathname", username);
+									"for one of the directories in the path prefix of pathname", ouid);
 				}
 				break;
 			}

--- a/src/c/ngx_http_clojure_module.c
+++ b/src/c/ngx_http_clojure_module.c
@@ -1671,7 +1671,7 @@ static ngx_int_t ngx_http_clojure_check_access_jvm_cp(ngx_http_clojure_main_conf
 			}
 			ngx_log_debug2(NGX_LOG_DEBUG_CORE, log, 0, "geteuid now %ud:%ud", geteuid(), getegid());
 		}
-		
+
 		for (i = 0; i < mcf->jvm_cp->nelts; i++) {
 			ngx_log_debug2(NGX_LOG_DEBUG_CORE, log, 0, "checking %V, nginx user with id : %ud ", &elts[i], ouid);
 			if (ngx_http_clojure_faccessat((char *)elts[i].data, log) != 0) {


### PR DESCRIPTION
When checking accessibility of jvm classpath in ngx_http_clojure_check_access_jvm_cp() , 
made changes replace username with user ID in the DEBUG logs.

In containerised environments where user id may be assigned from a pre-configured range, POSIX method getpwuid(user id) may fail as there is no entry for this user in /etc/passwd , leading to startup failure.

resolves #298 