### PR TITLE
Fix use-after-free when a rewrite-phase handler returns a direct response on a keepalive connection

### DIFF
--- a/src/java/nginx/clojure/NginxClojureRT.java
+++ b/src/java/nginx/clojure/NginxClojureRT.java
@@ -1627,6 +1627,25 @@ public class NginxClojureRT extends MiniConstants {
 		if (rc == NGX_OK &&  phase != -1) {
 			ngx_http_ignore_next_response(nr);
 		}
+		if (phase == NGX_HTTP_REWRITE_PHASE) {
+			/*
+			 * We are executing synchronously *inside* the rewrite phase handler
+			 * (ngx_http_clojure_rewrite_handler) on the nginx main thread, and the full
+			 * response has already been sent above. Calling ngx_http_finalize_request()
+			 * here (as handleReturnCodeFromHandler does for a phase handler) finalizes the
+			 * request from under the still-running phase engine; under HTTP keepalive that
+			 * path (ngx_http_finalize_connection -> ngx_http_set_keepalive ->
+			 * ngx_http_free_request) synchronously frees the request and its pool -- including
+			 * this module's ctx, which the surrounding C rewrite handler dereferences right
+			 * after we return and which ngx_http_run_posted_requests() also touches -- causing
+			 * a use-after-free (worker SIGSEGV/SIGABRT under load, e.g. redirect responses on a
+			 * reused keepalive connection). Instead hand the return code back to the phase
+			 * checker (ngx_http_core_rewrite_phase) and let *it* finalize after this handler
+			 * has fully unwound, exactly like the content phase (phase == -1) already does.
+			 * NGX_OK makes the checker finalize the already-sent response cleanly.
+			 */
+			return (int) (rc == NGX_ERROR ? NGX_ERROR : NGX_OK);
+		}
 		return (int)handleReturnCodeFromHandler(nr, phase, rc, status);
 	}
 

--- a/test/clojure/nginx/clojure/test_all.clj
+++ b/test/clojure/nginx/clojure/test_all.clj
@@ -135,6 +135,50 @@
              (is (= "my=test" (b :query-string)))
              (is (= "utf-8" (b :character-encoding))))))
 
+(deftest ^{:remote true} test-redirect-keepalive-no-uaf
+  (testing "many 301 redirects over one reused keepalive connection do not crash the worker"
+    ;; Regression test for the rewrite-phase use-after-free: a java rewrite handler that
+    ;; returns a direct 301 response used to finalize the request from *inside* the rewrite
+    ;; phase, so under HTTP keepalive ngx_http_set_keepalive() freed the request and its pool
+    ;; (including the module ctx) while the phase engine was still unwinding. Replaying many
+    ;; redirects on a single reused connection reliably tripped it -- run the worker under
+    ;; AddressSanitizer to catch the free/use, or watch for a worker SIGSEGV/SIGABRT.
+    (let [n 300
+          sock (java.net.Socket. ^String *host* (Integer/parseInt *port*))]
+      (try
+        (.setSoTimeout sock 10000)
+        (let [out (.getOutputStream sock)
+              in  (.getInputStream sock)
+              read-line (fn []
+                          (let [sb (StringBuilder.)]
+                            (loop []
+                              (let [c (.read in)]
+                                (cond
+                                  (= c -1) (when (pos? (.length sb)) (.toString sb))
+                                  (= c 10) (.toString sb)
+                                  (= c 13) (recur)
+                                  :else (do (.append sb (char c)) (recur)))))))
+              req (.getBytes (str "GET /javarewrite/redirect HTTP/1.1\r\n"
+                                  "Host: " *host* "\r\n"
+                                  "Connection: keep-alive\r\n\r\n")
+                             "ascii")]
+          (dotimes [i n]
+            (.write out req)
+            (.flush out)
+            (let [status (read-line)]
+              (is (and status (.contains ^String status "301"))
+                  (str "request " i " expected a 301 status line, got: " status))
+              ;; drain headers (capture content-length) then read the body so the
+              ;; connection stays in sync for the next keepalive request
+              (loop [len 0]
+                (let [line (read-line)]
+                  (cond
+                    (nil? line) (is false (str "connection closed early while reading headers, request " i))
+                    (= line "") (dotimes [_ len] (.read in))
+                    :else (let [m (re-matches #"(?i)content-length:\s*(\d+)\s*" line)]
+                            (recur (if m (Integer/parseInt (second m)) len)))))))))
+        (finally (.close sock))))))
+
 (deftest ^{:remote true} test-form
   (testing "form method=get"
            (let [r (client/get (str "http://" *host* ":" *port* "/form") {:coerce :unexceptional, :query-params {:foo "bar"}})

--- a/test/java/nginx/clojure/java/RewriteHandlerTestSet4NginxJavaRingHandler.java
+++ b/test/java/nginx/clojure/java/RewriteHandlerTestSet4NginxJavaRingHandler.java
@@ -38,6 +38,27 @@ public class RewriteHandlerTestSet4NginxJavaRingHandler {
 		
 	}
 	
+	/**
+	 * Returns an HTTP 301 redirect (status + Location header + HTML body) directly from the
+	 * rewrite phase, mirroring a real-world redirect handler. This exercises the synchronous
+	 * rewrite-phase direct-response path in {@link NginxClojureRT#handleResponse}. Before the
+	 * use-after-free fix, hammering this handler over a reused HTTP keepalive connection
+	 * crashed the nginx worker: finalizing the request from inside the rewrite phase led to
+	 * ngx_http_set_keepalive() freeing the request and its pool (including the module ctx)
+	 * while the phase engine was still unwinding.
+	 */
+	public static class RedirectRewriteHandler implements NginxJavaRingHandler {
+		@Override
+		public Object[] invoke(Map<String, Object> request) {
+			return new Object[] {
+					Constants.NGX_HTTP_MOVED_PERMANENTLY,
+					ArrayMap.create("Content-Type", "text/html", "Location", "http://localhost:8080/moved"),
+					"<html><head><title>301 Moved Permanently</title></head>"
+							+ "<body><a href=\"http://localhost:8080/moved\">moved</a></body></html>"
+			};
+		}
+	}
+
 	public static class HeadersRewriteHandler implements NginxJavaRingHandler {
 		@Override
 		public Object[] invoke(Map<String, Object> request) throws IOException {

--- a/test/nginx-working-dir/conf/nginx-plain.conf
+++ b/test/nginx-working-dir/conf/nginx-plain.conf
@@ -328,6 +328,14 @@ http {
           handler_name 'nginx.clojure.java.RewriteHandlerTestSet4NginxJavaRingHandler$SimpleVarHandler';
        }
        
+       # Redirect (301) returned directly from a java rewrite handler. Used by
+       # test-redirect-keepalive-no-uaf to verify that emitting a direct response from the
+       # rewrite phase over a reused keepalive connection does not crash the worker.
+       location /javarewrite/redirect {
+          handler_type 'java';
+          rewrite_handler_name 'nginx.clojure.java.RewriteHandlerTestSet4NginxJavaRingHandler$RedirectRewriteHandler';
+       }
+       
        location /javarewriteheaders {
           handler_type 'java';
           rewrite_handler_name 'nginx.clojure.java.RewriteHandlerTestSet4NginxJavaRingHandler$HeadersRewriteHandler';


### PR DESCRIPTION
If a synchronous (non-coroutine) rewrite handler returns a full response instead of PHASE_DONE — for example a 301 with a Location header and a small HTML body — the worker can crash under load when the connection is keepalive. We ran into this in production on a redirect-heavy endpoint that was being scanned: the worker died with SIGSEGV/SIGABRT and the core pointed at ngx_http_set_lingering_close with r->loc_conf == NULL, on an idle keepalive connection that had already served several requests.

The cause is that handleResponse finalizes the request from inside the rewrite phase handler. For the rewrite/access phase, handleReturnCodeFromHandler calls ngx_http_finalize_request(r, rc) and returns NGX_DONE. When the response is complete and the connection is keepalive, that finalize runs ngx_http_finalize_connection -> ngx_http_set_keepalive -> ngx_http_free_request, which frees the request and its pool synchronously. That pool holds our module ctx. Control then returns into ngx_http_clojure_rewrite_handler, which still reads ctx (via ngx_http_clojure_try_set_reload_delay_timer and ctx->phase), and nginx's ngx_http_run_posted_requests reads c->data, which set_keepalive has just repointed at the http_connection. That is the use-after-free.

Content handlers don't hit this because they run with phase == -1: handleReturnCodeFromHandler returns the code without finalizing, and the content phase checker (ngx_http_core_content_phase) calls finalize only after the handler has already returned, so nothing touches the request afterwards.

This change makes the synchronous rewrite path do the same thing. The full response has already been sent with ngx_http_send_header and ngx_http_output_filter, so instead of finalizing inline we return NGX_OK and let the phase checker (ngx_http_core_rewrite_phase) call finalize once the handler has fully unwound. The async handlePostedResponse path is left as is, since it finalizes from a posted event rather than from inside the phase engine.

I kept this to the rewrite phase on purpose. The access phase checker treats NGX_OK as "continue to the next phase", so the same approach doesn't map cleanly there, and returning a full body from an access handler is an unusual case. Happy to look at access separately if you think it's worth covering.

Tested against nginx 1.31.3. I added a regression test: a java rewrite handler that returns a 301 (RedirectRewriteHandler), a /javarewrite/redirect location, and test-redirect-keepalive-no-uaf, which replays a few hundred redirects over a single reused keepalive connection. Built with -fsanitize=address, that test reports the heap-use-after-free before the change and passes after it.

Closes #311